### PR TITLE
misc/log: print foo, not nil, in (log "foo") output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+* `clojure.tools.nrepl.misc/log` now logs all the arguments passed in,
+  without enforcing the conversion to Throwable even when the argument
+  is not an instance of Throwable.
+
 [`0.3.0`](https://github.com/clojure-emacs/nREPL/milestone/2?closed=1):
 
 * Materially identical to `[org.clojure/tools.nrepl "0.2.13"]`, but released under

--- a/src/main/clojure/clojure/tools/nrepl/misc.clj
+++ b/src/main/clojure/clojure/tools/nrepl/misc.clj
@@ -9,12 +9,12 @@
   (catch Throwable t
     ;(println "clojure.tools.logging not available, falling back to stdout/err")
     (defn log
-      [ex & msgs]
-      (let [ex (when (instance? Throwable ex) ex)
-            msgs (if ex msgs (cons ex msgs))]
+      [ex-or-msg & msgs]
+      (let [ex (when (instance? Throwable ex-or-msg) ex-or-msg)
+            msgs (if ex msgs (cons ex-or-msg msgs))]
         (binding [*out* *err*]
-          (apply println "ERROR:" msgs)
-          (when ex (.printStackTrace ^Throwable ex)))))))
+          (apply println "ERROR:" msgs))
+        (when ex (.printStackTrace ^Throwable ex))))))
 
 (defmacro returning
   "Executes `body`, returning `x`."

--- a/src/test/clojure/clojure/tools/nrepl/misc_test.clj
+++ b/src/test/clojure/clojure/tools/nrepl/misc_test.clj
@@ -1,0 +1,21 @@
+(ns clojure.tools.nrepl.misc-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.tools.nrepl.misc :refer [log]]))
+
+
+(defmacro with-err-str
+  "Evaluates exprs in a context in which *err* is bound to a fresh
+  StringWriter.  Returns the string created by any nested printing
+  calls.
+
+  Taken from clojure.core/with-out-str and adjusted for *err*."
+  [& body]
+  `(let [s# (new java.io.StringWriter)]
+     (binding [*err* s#]
+       ~@body
+       (str s#))))
+
+
+(deftest log-test
+  (testing "That the log doesn't convert non Throwable to nil"
+    (is (= "ERROR: foo bar\n" (with-err-str (log "foo" "bar"))))))


### PR DESCRIPTION
This is really just resolving the issue https://github.com/clojure-emacs/nREPL/issues/18.
The patch was approved, but never merged. Packaging it here as a PR since it's low hanging fruit.

The patch was created by @rlbdv 2.5 years ago, but it never got applied. If you look at the issue linked above, it'll just take you to [this discussion on Clojure JIRA](https://dev.clojure.org/jira/browse/NREPL-84).

The original description of the patch:

> Previously (log "foo") would just convert any first argument that
> wasn't a Throwable to nil.

